### PR TITLE
remove fuseiso

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ live CD/DVD iso file should not exceed this limit.
 Note2: Install 32bit/x86 iso on the stick first if creating multiboot with both
 x86 and x86_64 arch images.
 
-Note3: Requires: syslinux, fuseiso, qemu-img and dd_rescue/ddrescue installed on the system running this.
+Note3: Requires: syslinux, qemu-img and dd_rescue/ddrescue installed on the system running this.
 
 Copy live-fat-stick to /usr/bin/ and chmod +x /usr/bin/live-fat-stick
 
@@ -60,7 +60,7 @@ if the iso file exceeds this limit.
 Note2: Install 32bit/x86 iso on the stick first if creating multiboot with both
 x86 and x86_64 arch images.
 
-Note3: Requires: grub2, fuseiso, qemu-img and dd_rescue/ddrescue installed on the system running this. On Ubuntu grub-pc-bin package is also needed.
+Note3: Requires: grub2, qemu-img and dd_rescue/ddrescue installed on the system running this. On Ubuntu grub-pc-bin package is also needed.
 
 Run this command as root (su -, not sudo)
 live-grub-stick isopath stickpartition

--- a/live-fat-stick
+++ b/live-fat-stick
@@ -75,7 +75,7 @@ need_help() {
         Note2: Install 32bit/x86 iso on the stick first if creating multiboot with both
         x86 and x86_64 arch images.
 
-        Note3: Requires: syslinux, fuseiso and dd_rescue/ddrescue installed on the system running this.
+        Note3: Requires: syslinux and dd_rescue/ddrescue installed on the system running this.
 
         Run this command as root (su -, not sudo)
                 live-fat-stick isopath stickpartition
@@ -176,10 +176,6 @@ if [[ ! -e /usr/bin/syslinux ]]; then
 	echo "syslinux not found, please install syslinux package"
 	exit 1
 fi
-if [[ ! -e /usr/bin/fuseiso ]]; then
-        echo "fuseiso not found, please install fuseiso package"
-        exit 1
-fi
 if [[ ! -e $(which qemu-img) ]]; then
        	echo "qemu-img not found, please install qemu-tools package"
        	exit 1
@@ -255,7 +251,7 @@ try_cp_with_progress () {
 	fi
 }
 copy_kernel_initrd () {
-	fuseiso $isopath $isomount &>/dev/null
+	mount -o loop $isopath $isomount &>/dev/null
 	echo "copying kernel and initrd from iso image to $stickdevpart"
 	if [[ $distroname == suse ]]; then
 		if [[ $PERSISTENT_IMAGE == true ]]; then

--- a/live-grub-stick
+++ b/live-grub-stick
@@ -73,7 +73,7 @@ need_help() {
         Note2: Install 32bit/x86 iso on the stick first if creating multiboot with both
         x86 and x86_64 arch images.
 
-        Note3: Requires: grub2, fuseiso and dd_rescue/ddrescue installed on the system running this.
+        Note3: Requires: grub2 and dd_rescue/ddrescue installed on the system running this.
 
         Run this command as root (su -, not sudo)
                 live-grub-stick isopath stickpartition
@@ -186,10 +186,6 @@ if [[ ! -e $(which $grubinstall) ]]; then
 	echo "$grubinstall command not found, please install grub2 package"
 	exit 1
 fi
-if [[ ! -e $(which fuseiso) ]]; then
-        echo "fuseiso not found, please install fuseiso package"
-        exit 1
-fi
 if [[ ! -e $1 ]]; then
 	echo "File $1 does not exist"
 	exit 1
@@ -261,7 +257,7 @@ try_cp_with_progress () {
 	fi
 }
 cfg_setup() {
-	fuseiso $isopath $isomount &>/dev/null
+	mount -o loop $isopath $isomount &>/dev/null
         if [[ -d $stickmount/boot/grub2 ]]; then
                 grub2path=$stickmount/boot/grub2
                 grub2pathrealusb=/boot/grub2


### PR DESCRIPTION
Fuseiso is an unnecessary dependency since the script is run as root and the image can just be mounted as a loop device.